### PR TITLE
Fix queue time calculation

### DIFF
--- a/gh_actions_exporter/metrics.py
+++ b/gh_actions_exporter/metrics.py
@@ -187,6 +187,6 @@ class Metrics(object):
                         - webhook.workflow_job.started_at.timestamp())
             self.job_duration.labels(**labels).observe(duration)
         elif webhook.workflow_job.status == "in_progress":
-            duration = (webhook.workflow_job.steps[0].completed_at.timestamp()
+            duration = (webhook.workflow_job.steps[0].started_at.timestamp()
                         - webhook.workflow_job.started_at.timestamp())
             self.job_start_duration.labels(**labels).observe(duration)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -64,8 +64,8 @@ def workflow_job():
                     "status": "in_progress",
                     "conclusion": None,
                     "number": 1,
-                    "started_at": "2021-11-29T14:46:57Z",
-                    "completed_at": "2021-11-29T14:54:57Z"
+                    "started_at": "2021-11-29T14:50:57Z",
+                    "completed_at": None
                 }
             ],
             "labels": ["github-hosted"]

--- a/tests/api/test_job.py
+++ b/tests/api/test_job.py
@@ -24,7 +24,7 @@ def test_workflow_job_in_progress(client, workflow_job, headers):
         if 'inprogress_count_total{' in line:
             assert "1.0" in line
         if 'start_duration_seconds_sum{' in line:
-            assert '480.0' in line
+            assert '240.0' in line
 
 
 def test_workflow_job_label_self_hosted(client, workflow_job, headers):
@@ -56,4 +56,4 @@ def test_multiple_job_runs(client, workflow_job, headers):
         if 'job_total_count_total{' in line:
             assert '1.0' in line
         if 'job_start_duration_seconds_sum{' in line:
-            assert '480.0' in line
+            assert '240.0' in line


### PR DESCRIPTION
```
{
  "action": "in_progress",
  "workflow_job": {
    "id": 6795866685,
    "run_id": 2462295374,
    "run_url": "https://api.github.com/repos/scality/docs-ring-s3c/actions/runs/2462295374",
    "run_attempt": 1,
    "node_id": "CR_kwDOEPfzHc8AAAABlRCyPQ",
    "head_sha": "1f255afcae3c1b65f1a3def3585e947a1f4ae9c4",
    "url": "https://api.github.com/repos/scality/docs-ring-s3c/actions/jobs/6795866685",
    "html_url": "https://github.com/scality/docs-ring-s3c/runs/6795866685?check_suite_focus=true",
    "status": "in_progress",
    "conclusion": null,
    "started_at": "2022-06-08T14:41:24Z",
    "completed_at": null,
    "name": "build-image",
    "steps": [
      {
        "name": "Set up job",
        "status": "in_progress",
        "conclusion": null,
        "number": 1,
        "started_at": "2022-06-08T14:41:23.000Z",
        "completed_at": null
      }
    ],
    "check_run_url": "https://api.github.com/repos/scality/docs-ring-s3c/check-runs/6795866685",
    "labels": [
      "ubuntu-20.04"
    ],
    "runner_id": 16,
    "runner_name": "GitHub Actions 16",
    "runner_group_id": 2,
    "runner_group_name": "GitHub Actions"
  },
```

This is the webhook received when a job is started, and the `completed_at` is "null" we must use the `started_at` then.