### PR TITLE
RELENG-7210 Tracking cost of jobs

### DIFF
--- a/gh_actions_exporter/Webhook.py
+++ b/gh_actions_exporter/Webhook.py
@@ -32,6 +32,7 @@ class WebhookManager(object):
     def workflow_job(self):
         self.metrics.handle_job_status(self.payload, self.settings)
         self.metrics.handle_job_duration(self.payload, self.settings)
+        self.metrics.handle_job_cost(self.payload, self.settings)
 
     def ping(self):
         logger.info('Ping from Github')

--- a/gh_actions_exporter/config.py
+++ b/gh_actions_exporter/config.py
@@ -36,6 +36,15 @@ class ConfigFile(BaseSettings):
 
 class Settings(BaseSettings):
     job_relabelling: Optional[List[Relabel]] = []
+    job_costs: Optional[Dict[str, float]] = {
+        'medium': 0.008,
+        'large': 0.016,
+        'xlarge': 0.032,
+        '2xlarge': 0.064,
+        '3xlarge': 0.128
+    }
+    flavor_label: Optional[str] = 'flavor'
+    default_cost: Optional[float] = 0.008
 
     class Config:
         config: ConfigFile = ConfigFile()

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -9,22 +9,32 @@ from prometheus_client import REGISTRY
 
 @lru_cache()
 def job_relabel_config():
-    return Settings(job_relabelling=[
-        Relabel(
-            label="cloud",
-            values=[
-                "mycloud"
-            ],
-            type="name",
-            default="github-hosted"
-        ),
-        Relabel(
-            label="image",
-            values=[
-                "ubuntu-latest"
-            ],
-        )
-    ])
+    return Settings(
+        job_relabelling=[
+            Relabel(
+                label="cloud",
+                values=[
+                    "mycloud"
+                ],
+                type="name",
+                default="github-hosted"
+            ),
+            Relabel(
+                label="image",
+                values=[
+                    "ubuntu-latest"
+                ],
+            ),
+
+            Relabel(
+                label="flavor",
+                values=[
+                    "large"
+                ],
+                default="medium"
+            )
+        ],
+    ),
 
 
 @lru_cache()

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -19,6 +19,7 @@ def job_relabel_config():
                 type="name",
                 default="github-hosted"
             ),
+
             Relabel(
                 label="image",
                 values=[

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -34,7 +34,7 @@ def job_relabel_config():
                 default="medium"
             )
         ],
-    ),
+    )
 
 
 @lru_cache()

--- a/tests/api/test_job.py
+++ b/tests/api/test_job.py
@@ -86,3 +86,20 @@ def test_job_relabel(override_job_config, client, workflow_job, headers):
         if "image=\"ubuntu-latest\"" in line:
             result = True
     assert result is True
+
+
+def test_job_cost(client, workflow_job, headers):
+    metrics = client.get('/metrics')
+    for line in metrics.text.split('\n'):
+        if 'github_actions_job_cost_count_total{' in line:
+            assert '0.0' in line
+
+    workflow_job['workflow_job']['conclusion'] = 'success'
+    workflow_job['workflow_job']['completed_at'] = '2021-11-29T14:59:57Z'
+    response = client.post('/webhook', json=workflow_job, headers=headers)
+    assert response.status_code == 202
+
+    metrics = client.get('/metrics')
+    for line in metrics.text.split('\n'):
+        if 'github_actions_job_cost_count_total{' in line:
+            assert '0.0' not in line

--- a/tests/api/test_job.py
+++ b/tests/api/test_job.py
@@ -102,4 +102,4 @@ def test_job_cost(client, workflow_job, headers):
     metrics = client.get('/metrics')
     for line in metrics.text.split('\n'):
         if 'github_actions_job_cost_count_total{' in line:
-            assert '0.0' not in line
+            assert '0.104' in line


### PR DESCRIPTION
Adding a new metric `github_actions_job_cost_count` which will count the cost of jobs taking into account the flavor requested. 

This metric should allow us to track the cost of both github-hosted and self-hosted runners.
