### PR TITLE
PTFE-246: bump ingress apiversion of gh-exporter

### DIFF
--- a/charts/gh-action-exporter/templates/ingress.yaml
+++ b/charts/gh-action-exporter/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "gh-action-exporter.fullname" . }}
@@ -23,9 +23,12 @@ spec:
       http:
         paths:
           - path: {{ .Values.ingress.path | quote }}
+            pathType: Prefix
             backend:
-              serviceName: {{ include "gh-action-exporter.fullname" . }}
-              servicePort: {{ $.Values.service.port }}
+                service:
+                  name: {{ include "gh-action-exporter.fullname" . }}
+                  port:
+                    number: {{ $.Values.service.port }}
   {{- if .Values.ingress.tls }}
   tls:
     - hosts:


### PR DESCRIPTION
due to a cluster upgrade apiversion v1beta is no longer supported