### PR TITLE
Create .github/release.yaml configuration

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,6 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - dependencies


### PR DESCRIPTION
This pull request introduces a new configuration file, `.github/release.yaml`, which includes a section for generating a changelog. The most important change is the addition of an `exclude` subsection to exclude the `dependencies` label from the generated changelog.

Main configuration change:

* <a href="diffhunk://#diff-24062042b314111e98256591b30db43bb6fa4b9f1767cce24303a940808346aeR1-R6">`.github/release.yaml`</a>: Added a `changelog` section with an `exclude` subsection to exclude the `dependencies` label from the changelog generation.