### PR TITLE
Downgrade python 3.12 to 3.11

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Python 3",
-  "image": "mcr.microsoft.com/devcontainers/python:0-3.10",
+  "image": "mcr.microsoft.com/devcontainers/python:0-3.11",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {
       "version": "latest"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ jobs:
         run: pip install poetry
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: poetry
       - name: Install dependencies
         run: poetry install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.11
 
 EXPOSE 8000
 


### PR DESCRIPTION
Also making sure the right version of python is used across the board (GitHub Actions, devcontainers, and Dockerfile). 

Fixes #195

